### PR TITLE
Changing split_once to split in parse_Template func

### DIFF
--- a/rrgen/tests/fixtures/test1/template.t
+++ b/rrgen/tests/fixtures/test1/template.t
@@ -27,7 +27,6 @@ injections:
   content: ""
   remove_lines: "Delete this line"
 ---
-
 hello, this is the file body.
 
 variable: {{ name | pascal_case }}

--- a/rrgen/tests/gen_test.rs
+++ b/rrgen/tests/gen_test.rs
@@ -31,33 +31,33 @@ fn test_generate() {
     assert!(!dir_diff::is_different(GENERATED, "tests/fixtures/test1/expected").unwrap());
 }
 
-#[test]
-fn test_realistic() {
-    let FROM = "tests/fixtures/realistic/app";
-    let GENERATED = "tests/fixtures/realistic/generated";
+// #[test]
+// fn test_realistic() {
+//     let FROM = "tests/fixtures/realistic/app";
+//     let GENERATED = "tests/fixtures/realistic/generated";
 
-    let vars = json!({"name": "email_stats"});
-    fs_extra::dir::remove(GENERATED).unwrap();
-    fs_extra::dir::copy(
-        FROM,
-        GENERATED,
-        &CopyOptions {
-            copy_inside: true,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-    let rgen = RRgen::default();
+//     let vars = json!({"name": "email_stats"});
+//     fs_extra::dir::remove(GENERATED).unwrap();
+//     fs_extra::dir::copy(
+//         FROM,
+//         GENERATED,
+//         &CopyOptions {
+//             copy_inside: true,
+//             ..Default::default()
+//         },
+//     )
+//     .unwrap();
+//     let rgen = RRgen::default();
 
-    rgen.generate(
-        &fs::read_to_string("tests/fixtures/realistic/controller.t").unwrap(),
-        &vars,
-    )
-    .unwrap();
-    rgen.generate(
-        &fs::read_to_string("tests/fixtures/realistic/task.t").unwrap(),
-        &vars,
-    )
-    .unwrap();
-    assert!(!dir_diff::is_different(GENERATED, "tests/fixtures/realistic/expected").unwrap());
-}
+//     rgen.generate(
+//         &fs::read_to_string("tests/fixtures/realistic/controller.t").unwrap(),
+//         &vars,
+//     )
+//     .unwrap();
+//     rgen.generate(
+//         &fs::read_to_string("tests/fixtures/realistic/task.t").unwrap(),
+//         &vars,
+//     )
+//     .unwrap();
+//     assert!(!dir_diff::is_different(GENERATED, "tests/fixtures/realistic/expected").unwrap());
+// }

--- a/rrgen/tests/gen_test.rs
+++ b/rrgen/tests/gen_test.rs
@@ -31,33 +31,33 @@ fn test_generate() {
     assert!(!dir_diff::is_different(GENERATED, "tests/fixtures/test1/expected").unwrap());
 }
 
-// #[test]
-// fn test_realistic() {
-//     let FROM = "tests/fixtures/realistic/app";
-//     let GENERATED = "tests/fixtures/realistic/generated";
+#[test]
+fn test_realistic() {
+    let FROM = "tests/fixtures/realistic/app";
+    let GENERATED = "tests/fixtures/realistic/generated";
 
-//     let vars = json!({"name": "email_stats"});
-//     fs_extra::dir::remove(GENERATED).unwrap();
-//     fs_extra::dir::copy(
-//         FROM,
-//         GENERATED,
-//         &CopyOptions {
-//             copy_inside: true,
-//             ..Default::default()
-//         },
-//     )
-//     .unwrap();
-//     let rgen = RRgen::default();
+    let vars = json!({"name": "email_stats"});
+    fs_extra::dir::remove(GENERATED).unwrap();
+    fs_extra::dir::copy(
+        FROM,
+        GENERATED,
+        &CopyOptions {
+            copy_inside: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let rgen = RRgen::default();
 
-//     rgen.generate(
-//         &fs::read_to_string("tests/fixtures/realistic/controller.t").unwrap(),
-//         &vars,
-//     )
-//     .unwrap();
-//     rgen.generate(
-//         &fs::read_to_string("tests/fixtures/realistic/task.t").unwrap(),
-//         &vars,
-//     )
-//     .unwrap();
-//     assert!(!dir_diff::is_different(GENERATED, "tests/fixtures/realistic/expected").unwrap());
-// }
+    rgen.generate(
+        &fs::read_to_string("tests/fixtures/realistic/controller.t").unwrap(),
+        &vars,
+    )
+    .unwrap();
+    rgen.generate(
+        &fs::read_to_string("tests/fixtures/realistic/task.t").unwrap(),
+        &vars,
+    )
+    .unwrap();
+    assert!(!dir_diff::is_different(GENERATED, "tests/fixtures/realistic/expected").unwrap());
+}


### PR DESCRIPTION
Hey,
I don't know if this is a issue for me only but when I ran the code it gave me a error, when I was trying to split the template into
frontmatter and body in the parse template function in lib.rs

the error was the defined "cannot split document to frontmatter and body"
I changed the function to split and removed new line escape character and now it works, let me know if I am missing something
I made this pull request just incase it is not a local issue