### PR TITLE
External tera template

### DIFF
--- a/rrgen/Cargo.toml
+++ b/rrgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrgen"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Allow overriding with a custom Tera instance.
This enables the addition of custom functions or filters to Tera, which can then be utilized in rrgen.